### PR TITLE
Fix pgAdmin email domain

### DIFF
--- a/0-data-engineer/ex01/docker-compose.yml
+++ b/0-data-engineer/ex01/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         COPY servers.json /pgadmin4/servers.json
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: "dlu@student.42belrin.de"
+      PGADMIN_DEFAULT_EMAIL: "dlu@student.42berlin.de"
       PGADMIN_DEFAULT_PASSWORD: "mysecretpassword"
       PGADMIN_CONFIG_SERVER_MODE: "False"
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"

--- a/1-data-warehouse/ex00/docker-compose.yml
+++ b/1-data-warehouse/ex00/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         COPY servers.json /pgadmin4/servers.json
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: "dlu@student.42belrin.de"
+      PGADMIN_DEFAULT_EMAIL: "dlu@student.42berlin.de"
       PGADMIN_DEFAULT_PASSWORD: "mysecretpassword"
       PGADMIN_CONFIG_SERVER_MODE: "False"
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"


### PR DESCRIPTION
## Summary
- correct pgAdmin default email domain in two docker-compose files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684338d72bec8326ad499c61826f1648